### PR TITLE
fix: use absolute docker image paths

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:latest
+FROM docker.io/library/ubuntu:latest
 ENV DEBIAN_FRONTEND noninteractive
 
 RUN apt-get update -q && apt-get upgrade -qy && apt-get install -qy \

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Feel free to create a Issue or PR.
 
 ## Usage
 ```shell
-docker pull chillfre4k/latex
+docker pull docker.io/chillfre4k/latex
 
 exec docker run --rm -i --user="$(id -u):$(id -g)" --net=none -v "$PWD":"/data" chillfre4k/latex pdflatex main.tex
 ```
@@ -21,7 +21,7 @@ exec docker run --rm -i --user="$(id -u):$(id -g)" --net=none -v "$PWD":"/data" 
 ## Examples
 ### Gitlab-CI
 ```yaml
-image: chillfre4k/latex:latest
+image: docker.io/chillfre4k/latex:latest
 
 build:
   script:


### PR DESCRIPTION
This in needed in order to build with podman.
podman requires absolute paths and does not default to any registry.